### PR TITLE
#51 Update diagram label to indicate that also token exchange may be used

### DIFF
--- a/identity-chaining-draft.md
+++ b/identity-chaining-draft.md
@@ -399,7 +399,8 @@ The flow when authorization servers act as client would look like this:
 |Domain A|          |Domain A     |         |Domain B     | |Domain B |
 +--------+          +-------------+         +-------------+ +---------+
     |                      |                       |             |     
-    | (A) request token for|                       |             |     
+    | (A) request or       |                       |             |  
+    | exchange token for   |                       |             |     
     | protected resource   |                       |             |     
     | in domain B.         |                       |             |     
     | -------------------->|                       |             |     


### PR DESCRIPTION
Based on Kelly's feedback changing a label in the diagram in the appendix to indicate that also token exchange may be used. This is at the step when the client request a token for a protected resource in a different domain from its own authorization server. 