### PR TITLE
#47 Update authorization server discovery usage

### DIFF
--- a/identity-chaining-draft.md
+++ b/identity-chaining-draft.md
@@ -50,30 +50,8 @@ normative:
 
 informative:
 
-  SD-JWT:
-    title: Selective Disclosure for JWTs (SD-JWT)
-    target: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt-04
-    author:
-    - name: Daniel Fett
-      org: yes.com
-    - name: Kristina Yasuda
-      org: Microsoft
-    - name: Brian Campbell
-      org: Ping Identity
-
-  OAUTH2-BCP:
-    title: OAuth 2.0 Security Best Current Practice
-    target: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics
-    author:
-    - name: T. Lodderstedt
-      org: yes.com
-    - name: J. Bradley
-      org: Yubico
-    - name: A. Labunets
-      org: Independent Researcher
-    - name: D. Fett
-      org: Authlete
-
+  I-D.ietf-selective-disclosure-jwt:
+  I-D.ietf-oauth-security-topics:
   I-D.ietf-oauth-resource-metadata:
 
 
@@ -301,7 +279,7 @@ Cache-Control: no-cache, no-store
 Authorization servers MAY transcribe claims when either producing authorization grants in the token exchange flow or access tokens in the assertion flow.
 
 * **Transcribing the subject identifier**: Subject identifier can differ between the parties involved. For instance: A user is known at domain A by "johndoe@a.org" but in domain B by "doe.john@b.org". The mapping from one identifier to the other MAY either happen in the token exchange step and the updated identifer is reflected in returned authorization grant or in the assertion step where the updated identifier would be reflected in the access token. To support this both authorization servers MAY add, change or remove claims as described above.
-* **Selective disclosure**: Authorization servers MAY remove or hide certain due to privacy requirements or reduced trust towards the targeting trust domain. To hide and enclose claims {{SD-JWT}} MAY be used.
+* **Selective disclosure**: Authorization servers MAY remove or hide certain due to privacy requirements or reduced trust towards the targeting trust domain. To hide and enclose claims {{I-D.ietf-selective-disclosure-jwt}} MAY be used.
 * **Controlling scope**: Clients MAY use the scope parameter to control transcribed claims (e.g. downscoping). Authorization Servers SHOULD verify that requested scopes are not higher priveleged than the scopes of presented subject_token.
 * **Including authorization grant claims**: The authorization server performing the assertion flow MAY leverage claims from the presented authorization grant and include them in the returned access token. The populated claims SHOULD be namespaced or validated to prevent the injection of invalid claims.
 
@@ -314,7 +292,7 @@ To be added.
 # Security Considerations {#Security}
 
 ## Client Authentication
-Authorization Servers SHOULD follow the OAuth 2.0 Security Best Current Practice {{OAUTH2-BCP}} for client authentication.
+Authorization Servers SHOULD follow the OAuth 2.0 Security Best Current Practice {{I-D.ietf-oauth-security-topics}} for client authentication.
 
 --- back
 

--- a/identity-chaining-draft.md
+++ b/identity-chaining-draft.md
@@ -74,16 +74,7 @@ informative:
     - name: D. Fett
       org: Authlete
 
-  OAUTH2-PROTECTED-RESOURCE-METADATA:
-    title: OAuth 2.0 Protected Resource Metadata
-    target: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-resource-metadata-00\
-    author:
-    - name: M.B. Jones
-      org: Self-Issued Consulting
-    - name: P. Hunt
-      org: Independent Identity, Inc.
-    - name: Aaron Parecki
-      org: Okta
+  I-D.ietf-oauth-resource-metadata:
 
 
 --- abstract
@@ -170,7 +161,7 @@ The flow illustrated in Figure 1 shows the steps the client in trust Domain A ne
 * (F) The client now possesses an access token to access the protected resource in Domain B.
 
 ## Authorization Server Discovery
-This specification does not define authorization server discovery. A client MAY maintain a static mapping or use other means to identify the authorization server. The `authorization_servers` property in {{OAUTH2-PROTECTED-RESOURCE-METADATA}} MAY be used.
+This specification does not define authorization server discovery. A client MAY maintain a static mapping or use other means to identify the authorization server. The `authorization_servers` property in {{I-D.ietf-oauth-resource-metadata}} MAY be used.
 
 ## Token Exchange
 The client performs token exchange as defined in {{RFC8693}} with the authorization server for its own domain (e.g., Domain A) in order to obtain an authorization grant that can be used with the authorization server of a different domain (e.g., Domain B) as specified in section 1.3 of {{RFC6749}}.
@@ -377,7 +368,7 @@ The flow would look like this:
 
 The flow contains the following steps:
 
-(A) The resource server of domain A needs to access protected resource in Domain B. It requires an access token to do so which it does not possess. In this example {{OAUTH2-PROTECTED-RESOURCE-METADATA}} is used to receive information about the authorization server which protects the resource in domain B. This step MAY be skipped if discovery is not needed and other means of discovery MAY be used. The protected resource returns its metadata along with the authorization server information.
+(A) The resource server of domain A needs to access protected resource in Domain B. It requires an access token to do so which it does not possess. In this example {{I-D.ietf-oauth-resource-metadata}} is used to receive information about the authorization server which protects the resource in domain B. This step MAY be skipped if discovery is not needed and other means of discovery MAY be used. The protected resource returns its metadata along with the authorization server information.
 
 (B) Now, after the resource server has identified the authorization server for Domain B, the resource server requests an authorization grant for the authorization server in Domain B from its own authorization server (Domain A). This happens via the token exchange protocol.
 

--- a/identity-chaining-draft.md
+++ b/identity-chaining-draft.md
@@ -377,7 +377,7 @@ The flow would look like this:
 
 The flow contains the following steps:
 
-(A) The resource server of domain A needs to access protected resource in Domain B. It requires an access token to do so which it does not possess. In this example {{OAUTH2-PROTECTED-RESOURCE-METADATA}} is used to receive information about the authorization server which protecs the resource in domain B. Step A and B MAY be skipped if discovery is not needed and other means of discovery MAY be used. The protected resource returns its metadata along with the authorization server information.
+(A) The resource server of domain A needs to access protected resource in Domain B. It requires an access token to do so which it does not possess. In this example {{OAUTH2-PROTECTED-RESOURCE-METADATA}} is used to receive information about the authorization server which protects the resource in domain B. This step MAY be skipped if discovery is not needed and other means of discovery MAY be used. The protected resource returns its metadata along with the authorization server information.
 
 (B) Now, after the resource server has identified the authorization server for Domain B, the resource server requests an authorization grant for the authorization server in Domain B from its own authorization server (Domain A). This happens via the token exchange protocol.
 

--- a/identity-chaining-draft.md
+++ b/identity-chaining-draft.md
@@ -43,7 +43,6 @@ contributor:
 
 normative:
   RFC6749: # OAuth 2.0 Authorization Framework
-  RFC6750: # The OAuth 2.0 Authorization Framework: Bearer Token Usage
   RFC8693: # OAuth 2.0 Token Exchange
   RFC7521: # Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants
   RFC7523: # JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants
@@ -74,6 +73,18 @@ informative:
       org: Independent Researcher
     - name: D. Fett
       org: Authlete
+
+  OAUTH2-PROTECTED-RESOURCE-METADATA:
+    title: OAuth 2.0 Protected Resource Metadata
+    target: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-resource-metadata-00\
+    author:
+    - name: M.B. Jones
+      org: Self-Issued Consulting
+    - name: P. Hunt
+      org: Independent Identity, Inc.
+    - name: Aaron Parecki
+      org: Okta
+
 
 --- abstract
 
@@ -159,7 +170,7 @@ The flow illustrated in Figure 1 shows the steps the client in trust Domain A ne
 * (F) The client now possesses an access token to access the protected resource in Domain B.
 
 ## Authorization Server Discovery
-This specification does not define authorization server discovery. A client MAY contact the resource server and leverage the WWW-Authentication response (see section 3 of {{RFC6750}}), maintain a static mapping or use other means to identify the authorization server.
+This specification does not define authorization server discovery. A client MAY maintain a static mapping or use other means to identify the authorization server. The `authorization_servers` property in {{OAUTH2-PROTECTED-RESOURCE-METADATA}} MAY be used.
 
 ## Token Exchange
 The client performs token exchange as defined in {{RFC8693}} with the authorization server for its own domain (e.g., Domain A) in order to obtain an authorization grant that can be used with the authorization server of a different domain (e.g., Domain B) as specified in section 1.3 of {{RFC6749}}.
@@ -336,10 +347,9 @@ The flow would look like this:
 |Domain A     |          |Domain A|         |Domain B     | |Domain B |
 +-------------+          +--------+         +-------------+ +---------+
        |                     |                     |             |     
-       |                     |   (A) access (unauthenticated)    |     
+       |                     |   (A) request protected resource  |     
+       |                     |      metadata                     |     
        |                     | --------------------------------->|     
-       |                     |                     |             |     
-       |                     |   (B) <WWW-Authenticate header>   |     
        |                     | <- - - - - - - - - - - - - - - - -|     
        |                     |                     |             |     
        | (C) exchange token  |                     |             |     
@@ -367,19 +377,17 @@ The flow would look like this:
 
 The flow contains the following steps:
 
-(A) The resource server of domain A needs to access protected resource in Domain B. It requires an access token to do so which it does not possess. To receive information about the authorization server which protecs the resource in domain B it calls the resource unauthenticated.
+(A) The resource server of domain A needs to access protected resource in Domain B. It requires an access token to do so which it does not possess. In this example {{OAUTH2-PROTECTED-RESOURCE-METADATA}} is used to receive information about the authorization server which protecs the resource in domain B. Step A and B MAY be skipped if discovery is not needed and other means of discovery MAY be used. The protected resource returns its metadata along with the authorization server information.
 
-(B) The protected resource returns the WWW-Authenticate header to indicate its authorization server.
+(B) Now, after the resource server has identified the authorization server for Domain B, the resource server requests an authorization grant for the authorization server in Domain B from its own authorization server (Domain A). This happens via the token exchange protocol.
 
-(C) Now, after the resource server has identified the authorization server for Domain B, the resource server requests an authorization grant for the authorization server in Domain B from its own authorization server (Domain A). This happens via the token exchange protocol.
+(C) If successful, the authorization server returns an authorization grant to the resource server.
 
-(D) If successful, the authorization server returns an authorization grant to the resource server.
+(D) The resource server presents the authorization grant to the authorization server of Domain B.
 
-(E) The resource server presents the authorization grant to the authorization server of Domain B.
+(E) The authorization server of Domain B uses claims from the authorization grant to identify the user and its access. If access is granted an access token is returned.
 
-(F) The authorization server of Domain B uses claims from the authorization grant to identify the user and its access. If access is granted an access token is returned.
-
-(G) The resource server uses the access token to access the protected resource at Domain B.
+(F) The resource server uses the access token to access the protected resource at Domain B.
 
 ## Authorization server acting as client
 

--- a/identity-chaining-draft.md
+++ b/identity-chaining-draft.md
@@ -50,7 +50,7 @@ normative:
 
 informative:
 
-  I-D.ietf-selective-disclosure-jwt:
+  I-D.ietf-oauth-selective-disclosure-jwt:
   I-D.ietf-oauth-security-topics:
   I-D.ietf-oauth-resource-metadata:
 
@@ -279,7 +279,7 @@ Cache-Control: no-cache, no-store
 Authorization servers MAY transcribe claims when either producing authorization grants in the token exchange flow or access tokens in the assertion flow.
 
 * **Transcribing the subject identifier**: Subject identifier can differ between the parties involved. For instance: A user is known at domain A by "johndoe@a.org" but in domain B by "doe.john@b.org". The mapping from one identifier to the other MAY either happen in the token exchange step and the updated identifer is reflected in returned authorization grant or in the assertion step where the updated identifier would be reflected in the access token. To support this both authorization servers MAY add, change or remove claims as described above.
-* **Selective disclosure**: Authorization servers MAY remove or hide certain due to privacy requirements or reduced trust towards the targeting trust domain. To hide and enclose claims {{I-D.ietf-selective-disclosure-jwt}} MAY be used.
+* **Selective disclosure**: Authorization servers MAY remove or hide certain due to privacy requirements or reduced trust towards the targeting trust domain. To hide and enclose claims {{I-D.ietf-oauth-selective-disclosure-jwt}} MAY be used.
 * **Controlling scope**: Clients MAY use the scope parameter to control transcribed claims (e.g. downscoping). Authorization Servers SHOULD verify that requested scopes are not higher priveleged than the scopes of presented subject_token.
 * **Including authorization grant claims**: The authorization server performing the assertion flow MAY leverage claims from the presented authorization grant and include them in the returned access token. The populated claims SHOULD be namespaced or validated to prevent the injection of invalid claims.
 


### PR DESCRIPTION
Based on Brians feedback WWW-Authenticate cannot be used as it does not contain authorization server information.
He suggested to use https://datatracker.ietf.org/doc/html/[draft-ietf-oauth-resource-metadata-00](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-resource-metadata-00) instead.

This PR is removing WWW-Authenticate from the draft and suggest the reader to use protected resource metadata instead when authorization server discovery is needed.