### PR TITLE
Marking docname as adopted by the oauth working group

### DIFF
--- a/identity-chaining-draft.md
+++ b/identity-chaining-draft.md
@@ -6,7 +6,7 @@ submissiontype: IETF
 area: sec
 wg: oauth
 
-docname: draft-schwenkschuster-oauth-identity-chaining-00
+docname: draft-oauth-identity-chaining-00
 
 title: Identity Chaining across Trust Domains
 abbrev:


### PR DESCRIPTION
removing schwenkschuster from docname to indicate it has been WG-adopted