### PR TITLE
Move Mr. Parecki from contributor to author

### DIFF
--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -29,6 +29,9 @@ author:
 - name: Brian Campbell
   org: Ping Identity
   email: bcampbell@pingidentity.com
+- name: Aaron Parecki
+  org: Okta
+  email: aaron@parecki.com
 contributor:
 - name: Atul Tulshibagwale
   org: SGNL
@@ -41,9 +44,6 @@ contributor:
   email: rifaat.s.ietf@gmail.com
 - name: Hannes Tschofenig
   email: hannes.tschofenig@gmx.net
-- name: Aaron Parecki
-  org: Okta
-  email: aaron@parecki.com
 
 normative:
   RFC6749: # OAuth 2.0 Authorization Framework


### PR DESCRIPTION
https://github.com/oauth-wg/oauth-identity-chaining/pull/183#discussion_r3132074633 is the recent inspiration/motivation for this. Which, in case you don't want to click on the link:

<img width="934" height="1034" alt="Screenshot 2026-04-24 at 10 59 32 AM" src="https://github.com/user-attachments/assets/e4bae521-dc3e-4a4c-8287-b84c3c9ffa7f" />



and while it's a very imperfect metric this is one demonstration that he has indeed contributed: 

<img width="1321" height="1205" alt="Screenshot 2026-04-24 at 11 01 31 AM" src="https://github.com/user-attachments/assets/5bf99dcd-4292-4160-a4f3-942d95270084" />

