### PR TITLE
Remove some extraneous text from IANA Considerations

### DIFF
--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -52,14 +52,10 @@ normative:
   RFC7523: # JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants
   RFC8707: # Resource Indicators for OAuth 2.0
   RFC8414: # OAuth 2.0 Authorization Server Metadata
-  RFC8725: # JSON Web Token Best Current Practices
-  RFC2046: # Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types
-  RFC6838: # Media Type Specifications and Registration Procedures
   RFC9700: # Best Current Practice for OAuth 2.0 Security
   RFC9728: # OAuth 2.0 Protected Resource Metadata
 
 informative:
-  IANA.media-types:
 
 --- abstract
 
@@ -317,15 +313,6 @@ This specification requests registration of the following parameter in the "OAut
 * Change Controller: IETF
 * Specification Document(s): {{authorization-server-metadata}} of [[this document]]
 
-
-The parameter indicates the supported token types that can be requested in an {{RFC8693}} Token Exchange.
-
-
-## Media Types
-This specification does not define any new media types.
-
-Profiles or deployment-specific implementations can adopt explicit typing as defined in JSON Web Token Best Current Practices {{RFC8725}} and define a new media type {{RFC2046}} in the "Media Types" registry {{IANA.media-types}} in the manner described in {{RFC6838}}.
-
 # Security Considerations {#Security}
 
 ## Client Authentication
@@ -547,6 +534,10 @@ The editors would like to thank Deb Cooley, Lars Eggert, Patrick Harding, Russ H
 # Document History
 
 \[\[ To be removed from the final specification ]]
+
+-14
+
+* Remove some extraneous text from IANA Considerations
 
 -13
 


### PR DESCRIPTION
per https://mailarchive.ietf.org/arch/msg/oauth/FH8roNfk8zXeVXq1B-GpBVLE-w8/ and thread 

I didn't see a good place to move the explicit typing text or good reason to keep it 