### PR TITLE
Consistency of examples

### DIFF
--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -266,11 +266,7 @@ Content-Type: application/json
 Cache-Control: no-cache, no-store
 
 {
-  "access_token":"eyJhbGciOiJFUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJpc3MiOiJod
-  HRwczovL2FzLmIuZXhhbXBsZS9hdXRoIiwiZXhwIjoxNjk1Mjg3NzUyLCJpYXQiOjE2OTU
-  yODc2OTIsInN1YiI6ImRvZS5qb2huQGIuZXhhbXBsZSIsImF1ZCI6Imh0dHBzOi8vYi5le
-  GFtcGxlL2FwaSJ9.Fd0SMTM_Ylv9RM-Y65g4Fn5X6Lk8A8t8ndZ39zaEykvJpLp4-cwcsb
-  4018gZBHHG8AI5IDcu_hoLs0jdhwrJtA",
+  "access_token":"b./77-.ehs96cFAx~ac00~qG+z8N_x/4.RpL-2Ykc4~",
   "token_type":"Bearer",
   "expires_in":60
 }

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -541,6 +541,14 @@ The editors would like to thank Deb Cooley, Lars Eggert, Patrick Harding, Russ H
 
 \[\[ To be removed from the final specification ]]
 
+-17
+
+* Formatting changes to use bacticks consistently
+* Example consistency updates
+
+-16
+
+* Corrected author's name
 
 -15
 

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -266,11 +266,11 @@ Content-Type: application/json
 Cache-Control: no-cache, no-store
 
 {
-  "access_token":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwc
-  zovL2FzLmIuZXhhbXBsZS9hdXRoIiwiZXhwIjoxNjk1Mjg3NzUyLCJpYXQiOjE2OTUyODc
-  2OTIsInN1YiI6ImRvZS5qb2huQGIuZXhhbXBsZSIsImF1ZCI6Imh0dHBzOi8vYi5leGFtc
-  GxlL2FwaSJ9.kyd4-h3ZoV2sH212kLKbcOnCBajStKQ38Ae_bfT-PFIAUgB4-VGEvTfObt
-  Z_NipCtCY-1Mi6bXd7AWb5r4eYlw",
+  "access_token":"eyJhbGciOiJFUzI1NiIsInR5cCI6ImF0K2p3dCJ9.eyJpc3MiOiJod
+  HRwczovL2FzLmIuZXhhbXBsZS9hdXRoIiwiZXhwIjoxNjk1Mjg3NzUyLCJpYXQiOjE2OTU
+  yODc2OTIsInN1YiI6ImRvZS5qb2huQGIuZXhhbXBsZSIsImF1ZCI6Imh0dHBzOi8vYi5le
+  GFtcGxlL2FwaSJ9.Fd0SMTM_Ylv9RM-Y65g4Fn5X6Lk8A8t8ndZ39zaEykvJpLp4-cwcsb
+  4018gZBHHG8AI5IDcu_hoLs0jdhwrJtA",
   "token_type":"Bearer",
   "expires_in":60
 }

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -178,7 +178,7 @@ All of {{Section 2.2 of RFC8693}} applies. In addition, the following applies to
 
 ### Example
 
-The example below shows a message invoked by a client in trust domain A to perform token exchange with the authorization server in trust domain A (https://as.a.example/auth) to receive a JWT authorization grant for an authorization server in trust domain B (https://as.b.example/auth).
+The example below shows a message invoked by a client in trust domain A to perform token exchange with the authorization server in trust domain A (https://as.a.example/auth) to receive a JWT authorization grant for an authorization server in trust domain B (https://as.b.example/auth). Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable
 
 ~~~
 POST /auth/token HTTP/1.1
@@ -189,7 +189,7 @@ grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange
 &resource=https%3A%2F%2Fas.b.example%2Fauth
 &subject_token=ey...
 &subject_token_type=
- urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token
+urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token
 ~~~
 {: title='Example of Token Exchange Request'}
 
@@ -199,10 +199,11 @@ Content-Type: application/json
 Cache-Control: no-cache, no-store
 
 {
-  "access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJo
-  dHRwczovL2FzLmEub3JnL2F1dGgiLCJleHAiOjE2OTUyODQwOTIsImlhdCI6MTY5N
-  TI4NzY5Miwic3ViIjoiam9obl9kb2VAYS5vcmciLCJhdWQiOiJodHRwczovL2FzLm
-  Iub3JnL2F1dGgifQ.304Pv9e6PnzcQPzz14z-k2ZyZvDtP5WIRkYPScwdHW4",
+  "access_token":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwc
+  zovL2FzLmEuZXhhbXBsZS9hdXRoIiwiZXhwIjoxNjk1Mjg3NzUyLCJpYXQiOjE2OTUyODc
+  2OTIsInN1YiI6ImpvaG5kb2VAYS5leGFtcGxlIiwiYXVkIjoiaHR0cHM6Ly9hcy5iLmV4Y
+  W1wbGUvYXV0aCJ9.ajdodNb-_WRUD03_Ns1_0F12ksSclHO6WfIh8YHliRq4oJY038kKqr
+  J-EugSk_h6ehJ_A7h8UVK40edpkERCiQ",
   "token_type":"N_A",
   "issued_token_type":"urn:ietf:params:oauth:token-type:jwt",
   "expires_in":60
@@ -243,7 +244,7 @@ When the authorization grant has been validated, the authorization server in tru
 
 ### Example
 
-The examples below show how a client in trust domain A presents an authorization grant to the authorization server in trust domain B (https://as.b.example/auth) to receive an access token for a protected resource in trust domain B.
+The examples below show how a client in trust domain A presents an authorization grant to the authorization server in trust domain B (https://as.b.example/auth) to receive an access token for a protected resource in trust domain B. Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable
 
 ~~~
 POST /auth/token HTTP/1.1
@@ -261,10 +262,11 @@ Content-Type: application/json
 Cache-Control: no-cache, no-store
 
 {
-  "access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJo
-  dHRwczovL2FzLmIub3JnL2F1dGgiLCJleHAiOjE2OTUyODQwOTIsImlhdCI6MTY5N
-  TI4NzY5Miwic3ViIjoiam9obi5kb2UuMTIzIiwiYXVkIjoiaHR0cHM6Ly9iLm9yZy
-  9hcGkifQ.CJBuv6sr6Snj9in5T8f7g1uB61Ql8btJiR0IXv5oeJg",
+  "access_token":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwc
+  zovL2FzLmIuZXhhbXBsZS9hdXRoIiwiZXhwIjoxNjk1Mjg3NzUyLCJpYXQiOjE2OTUyODc
+  2OTIsInN1YiI6ImRvZS5qb2huQGIuZXhhbXBsZSIsImF1ZCI6Imh0dHBzOi8vYi5leGFtc
+  GxlL2FwaSJ9.kyd4-h3ZoV2sH212kLKbcOnCBajStKQ38Ae_bfT-PFIAUgB4-VGEvTfObt
+  Z_NipCtCY-1Mi6bXd7AWb5r4eYlw",
   "token_type":"Bearer",
   "expires_in":60
 }

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -244,7 +244,7 @@ When the authorization grant has been validated, the authorization server in tru
 
 ### Example
 
-The examples below show how a client in trust domain A presents an authorization grant to the authorization server in trust domain B (https://as.b.example/auth) to receive an access token for a protected resource in trust domain B. Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable.
+The examples below show how a client in trust domain A presents an authorization grant to the authorization server in trust domain B (https://as.b.example/auth) to receive an access token for a protected resource in trust domain B. Extra line breaks and indentation in the examples are for display purposes only. The JWT signature is for illustration only and is not verifiable.
 
 ~~~
 POST /auth/token HTTP/1.1

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -252,7 +252,11 @@ Host: as.b.example
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
-&assertion=ey...
+&assertion=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2Fz
+LmEuZXhhbXBsZS9hdXRoIiwiZXhwIjoxNjk1Mjg3NzUyLCJpYXQiOjE2OTUyODc2OTIsInN1
+YiI6ImpvaG5kb2VAYS5leGFtcGxlIiwiYXVkIjoiaHR0cHM6Ly9hcy5iLmV4YW1wbGUvYXV0
+aCJ9.ajdodNb-_WRUD03_Ns1_0F12ksSclHO6WfIh8YHliRq4oJY038kKqrJ-EugSk_h6ehJ
+_A7h8UVK40edpkERCiQ
 ~~~
 {: title='Assertion request'}
 

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -178,7 +178,7 @@ All of {{Section 2.2 of RFC8693}} applies. In addition, the following applies to
 
 ### Example
 
-The example below shows a message invoked by a client in trust domain A to perform token exchange with the authorization server in trust domain A (https://as.a.example/auth) to receive a JWT authorization grant for an authorization server in trust domain B (https://as.b.example/auth). Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable
+The example below shows a message invoked by a client in trust domain A to perform token exchange with the authorization server in trust domain A (https://as.a.example/auth) to receive a JWT authorization grant for an authorization server in trust domain B (https://as.b.example/auth). Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable.
 
 ~~~
 POST /auth/token HTTP/1.1

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -178,7 +178,7 @@ All of {{Section 2.2 of RFC8693}} applies. In addition, the following applies to
 
 ### Example
 
-The example below shows a message invoked by a client in trust domain A to perform token exchange with the authorization server in trust domain A (https://as.a.example/auth) to receive a JWT authorization grant for an authorization server in trust domain B (https://as.b.example/auth). Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable.
+The example below shows a message invoked by a client in trust domain A to perform token exchange with the authorization server in trust domain A (https://as.a.example/auth) to receive a JWT authorization grant for an authorization server in trust domain B (https://as.b.example/auth). Extra line breaks and indentation in the examples are for display purposes only. The JWT signature is for illustration only and is not verifiable.
 
 ~~~
 POST /auth/token HTTP/1.1

--- a/draft-ietf-oauth-identity-chaining.md
+++ b/draft-ietf-oauth-identity-chaining.md
@@ -244,7 +244,7 @@ When the authorization grant has been validated, the authorization server in tru
 
 ### Example
 
-The examples below show how a client in trust domain A presents an authorization grant to the authorization server in trust domain B (https://as.b.example/auth) to receive an access token for a protected resource in trust domain B. Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable
+The examples below show how a client in trust domain A presents an authorization grant to the authorization server in trust domain B (https://as.b.example/auth) to receive an access token for a protected resource in trust domain B. Extra line breaks and indentation in the examples are for display purposes only. The JWT signatures are for illustration only and are not verifiable.
 
 ~~~
 POST /auth/token HTTP/1.1


### PR DESCRIPTION
Changes to make the examples consistent with the text. Changes include: 

1. Domain names: .org -> .example (reserved TLD) in iss/aud/sub.
2. sub values: aligned to the text (johndoe@a.example (grant), doe.john@b.example (access token)).
3. Expiry after iat: exp set to iat + 60 (was before iat — expired at issuance).
4. alg: HS256 → ES256 (matches the public-key usage described in spec).
5. Illustrative signatures: full-length dummy signatures + a note that they're illustrative and not verifiable.